### PR TITLE
实际开发中有可能后台返回的json数据字段对应的值是<null>，对应到ios的字典里面就是一个NSNull的实例，这里做了一个判断，如果…

### DIFF
--- a/Reflect.xcodeproj/xcuserdata/marcosun.xcuserdatad/xcschemes/Reflect.xcscheme
+++ b/Reflect.xcodeproj/xcuserdata/marcosun.xcuserdatad/xcschemes/Reflect.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89B833691B842549002C60EB"
+               BuildableName = "Reflect.app"
+               BlueprintName = "Reflect"
+               ReferencedContainer = "container:Reflect.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89B8337E1B84254A002C60EB"
+               BuildableName = "ReflectTests.xctest"
+               BlueprintName = "ReflectTests"
+               ReferencedContainer = "container:Reflect.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89B833691B842549002C60EB"
+            BuildableName = "Reflect.app"
+            BlueprintName = "Reflect"
+            ReferencedContainer = "container:Reflect.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89B833691B842549002C60EB"
+            BuildableName = "Reflect.app"
+            BlueprintName = "Reflect"
+            ReferencedContainer = "container:Reflect.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89B833691B842549002C60EB"
+            BuildableName = "Reflect.app"
+            BlueprintName = "Reflect"
+            ReferencedContainer = "container:Reflect.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Reflect.xcodeproj/xcuserdata/marcosun.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Reflect.xcodeproj/xcuserdata/marcosun.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Reflect.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>89B833691B842549002C60EB</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>89B8337E1B84254A002C60EB</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Reflect/Reflect/Dict2Model/Reflect+Parse.swift
+++ b/Reflect/Reflect/Dict2Model/Reflect+Parse.swift
@@ -66,7 +66,18 @@ extension Reflect{
                             model.setValue(dict[key]?.boolValue, forKeyPath: name)
                             
                         }else{
-                            model.setValue(dict[key], forKeyPath: name)
+                            
+                            var dictValue = dict[key]
+                            
+                            if let tmp = dictValue {
+                                
+                                if tmp.isEqual(NSNull.init()) {
+                                    
+                                    dictValue = nil
+                                }
+                            }
+                            
+                            model.setValue(dictValue, forKeyPath: name)
                         }
                         
                         
@@ -75,7 +86,16 @@ extension Reflect{
                         
                         //这里是模型
                         //首选判断字典中是否有值
-                        let dictValue = dict[key]
+                        
+                        var dictValue = dict[key]
+                        
+                        if let tmp = dictValue {
+                            
+                            if tmp.isEqual(NSNull.init()) {
+                                
+                                dictValue = nil
+                            }
+                        }
                         
                         if dictValue != nil { //字典中有模型
                             


### PR DESCRIPTION
实际开发中有可能后台返回的json数据字段对应的值是<null>，对应到ios的字典里面就是一个NSNull的实例，这里做了一个判断，如果字典里的值是一个NSNull的实例，会转成一个nil值。不会在把这个null值赋值给模型的属性（如果赋值swift的基础类型会引起crash）。
